### PR TITLE
Remove strict comparison that breaks usage of table nodes ('Then the JSON node X should be equal to Y').

### DIFF
--- a/src/Asserter.php
+++ b/src/Asserter.php
@@ -76,7 +76,7 @@ trait Asserter
     protected function assertEquals($expected, $actual, string $message = null): void
     {
         $this->assert(
-            $expected === $actual,
+            $expected == $actual,
             $message ?: "The element '$actual' is not equal to '$expected'"
         );
     }

--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -57,7 +57,7 @@ class JsonContext extends BaseContext
         $json = $this->getJson();
         $actual = $this->inspector->evaluate($json, $node);
 
-        if ($actual !== $text) {
+        if ($actual != $text) {
             throw new \Exception(
                 \sprintf("The node value is '%s'", \json_encode($actual, JSON_THROW_ON_ERROR))
             );


### PR DESCRIPTION
Hello!

First, thanks for your work on this library. I just switched over to your fork to remove some deprecation warnings, and noticed that some of my tests broke because your "apply code style" commit was a bit too aggressive in some places.

What happens is that if you call a route returning a JSON with an integer value like `{"id": 42}`, you cannot use `Then the JSON node "id" should be equal to "42"` (nor `.. should be equal to 42`), because the `$text` variable will be a `string` (no matter the syntax used) while the `$actual` variable (coming from the JsonInspector) will be properly typed to `integer`.

So it seems like there was a "good reason" (or reason enough) for this condition not to be strict. This PR reverts it.