### PR TITLE
Remove data type checking in function theJsonNodeShouldBeEqualTo

### DIFF
--- a/src/Context/JsonContext.php
+++ b/src/Context/JsonContext.php
@@ -59,7 +59,7 @@ class JsonContext extends BaseContext
         $json = $this->getJson();
         $actual = $this->inspector->evaluate($json, $node);
 
-        if ($actual !== $text) {
+        if ($actual != $text) {
             throw new \Exception(
                 \sprintf(self::NODE_VALUE_IS, $node, \json_encode($actual, JSON_THROW_ON_ERROR))
             );


### PR DESCRIPTION
Hi, the functionality is equal between function `theJsonNodeShouldBeEqualTo` and function `theJsonNodeShouldBeEqualToTheString` currently.

I suggest the function `theJsonNodeShouldBeEqualTo` that compares the value without data type checking.